### PR TITLE
Synchronize party's videos

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -21,6 +21,7 @@
   "content_scripts": [
     {
       "matches": ["*://*.youtube.com/*"],
+      "run_at": "document_end",
       "css": ["/static/css/contentScript.css"],
       "js": ["/static/js/contentScript.js"]
     }

--- a/src/content-script/listeners/index.ts
+++ b/src/content-script/listeners/index.ts
@@ -3,7 +3,7 @@ import { debug, inject } from '@root/lib/utils';
 import { toggleChat } from '@contentScript/actions/chat';
 import { joinParty } from '@contentScript/actions/party';
 import store from '@contentScript/store';
-import '@contentScript/listeners/player';
+import { attachToVideoPlayer } from './player';
 
 /**
  * Our content script has a different browsing context than that of the current webpage
@@ -14,7 +14,7 @@ window.addEventListener('message', event => {
   switch (event.data.name) {
     case WindowMessages.URL_CHANGE:
       debug(event.data.name);
-      debug(document.location.href);
+      attachToVideoPlayer();
       break;
     case WindowMessages.PAGE_UNLOAD:
       debug(event.data);
@@ -23,6 +23,8 @@ window.addEventListener('message', event => {
       debug('Unknown Window Message Name');
   }
 });
+
+window.addEventListener('load', attachToVideoPlayer);
 
 // CANNOT REFERENCE ANY VARIABLES FROM OUTER SCOPE (They will not resolve)
 function addNavigationListeners() {

--- a/src/content-script/listeners/player.ts
+++ b/src/content-script/listeners/player.ts
@@ -1,7 +1,9 @@
 import { debug } from '@root/lib/utils';
 import socket from '@contentScript/socket';
 import store from '@contentScript/store';
-import { SocketEvents } from '@root/lib/constants/socket';
+import { SocketEvents, VideoSocketEvents } from '@root/lib/constants/socket';
+import { VideoEvent, VideoEventData } from '@root/lib/types/video';
+import { MAX_DESYNC_SEC } from '@root/lib/constants/video';
 import { SupportedPlatforms } from '@root/lib/types';
 
 //------------------------------------------------------------------------------
@@ -47,40 +49,68 @@ function findVideoPlayer(): HTMLVideoElement | null {
 //------------------------------------------------------------------------------
 
 function addVideoListeners(player: HTMLVideoElement) {
-  // TODO: hostRequired should default to true once that's implemented
-  function sendVideoEvent(socketEvent: SocketEvents, hostRequired = false) {
+  // TODO: Once implemented, include communism/facism check
+  function sendVideoEvent(socketEvent: VideoSocketEvents, hostRequired = true) {
     return (event: any) => {
       const state = store.getState();
-      const { isHost } = state.party;
-      const { id: partyId } = state.party;
-      const { currentTime, duration, playbackRate } = event.target;
+      const { isHost, hash } = state.party;
 
-      const payload = { partyId, currentTime, duration, playbackRate };
+      // if party not created, don't send anything
+      if (!hash) return;
 
+      // construct payload
+      const { paused, currentTime, duration, playbackRate } = event.target;
+      const eventData: VideoEventData = { eventType: socketEvent, isHost, paused, currentTime, playbackRate, duration };
+      const payload: VideoEvent = { partyHash: hash, eventData };
+
+      // send payload
       if (hostRequired && isHost) {
         debug(`Host emitting ${socketEvent}`);
-        socket.emit(socketEvent, payload);
+        socket.emit(SocketEvents.VIDEO_EVENT, payload);
       } else if (!hostRequired) {
         debug(`User emitting ${socketEvent}`);
-        socket.emit(socketEvent, payload);
+        socket.emit(SocketEvents.VIDEO_EVENT, payload);
       }
     };
   }
 
-  player.onplay = sendVideoEvent(SocketEvents.VIDEO_PLAY);
-  player.onpause = sendVideoEvent(SocketEvents.VIDEO_PAUSE);
-  player.onseeked = sendVideoEvent(SocketEvents.VIDEO_SEEKED);
-  player.onprogress = sendVideoEvent(SocketEvents.VIDEO_PROGRESS, false);
+  player.onplay = sendVideoEvent(VideoSocketEvents.VIDEO_PLAY);
+  player.onpause = sendVideoEvent(VideoSocketEvents.VIDEO_PAUSE);
+  player.onseeked = sendVideoEvent(VideoSocketEvents.VIDEO_SEEKED);
+  player.onprogress = sendVideoEvent(VideoSocketEvents.VIDEO_PROGRESS, false);
+}
+
+//------------------------------------------------------------------------------
+
+function addVideoSocketListeners(player: HTMLVideoElement) {
+  socket.on(SocketEvents.VIDEO_EVENT, (data: VideoEventData) => {
+    // TODO: Once implemented, include communism/facism check
+    if (data.isHost) {
+      // match player play/pause state
+      if (data.paused) player.pause();
+      else player.play();
+
+      // match player playback speed
+      player.playbackRate = data.playbackRate;
+
+      // resync if needed and not host. handles seek events
+      if (Math.abs(player.currentTime - data.currentTime) > MAX_DESYNC_SEC) {
+        player.currentTime = data.currentTime;
+      }
+    }
+  });
 }
 
 //------------------------------------------------------------------------------
 
 function attachToVideoPlayer() {
   const videoPlayer = findVideoPlayer();
-  if (videoPlayer) addVideoListeners(videoPlayer);
+  if (videoPlayer) {
+    addVideoListeners(videoPlayer);
+    addVideoSocketListeners(videoPlayer);
+  }
 }
 
 //------------------------------------------------------------------------------
 
 attachToVideoPlayer();
-// TODO: need to call attachToVideoPlayer every time URL_CHANGE occurs

--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -3,5 +3,6 @@ export * from './chat';
 export * from './popup';
 export * from './party';
 export * from './socket';
+export * from './video';
 export * from './window';
 export * from './user';

--- a/src/lib/constants/socket.ts
+++ b/src/lib/constants/socket.ts
@@ -3,14 +3,17 @@ export enum SocketEvents {
   SEND_MESSAGE = 'send_message',
   CONNECT = 'connect',
   CREATE_PARTY = 'create_party',
-
-  VIDEO_PLAY = 'video_play',
-  VIDEO_PAUSE = 'video_pause',
-  VIDEO_SEEKED = 'video_seeked',
-  VIDEO_PROGRESS = 'video_progress',
   JOIN_PARTY = 'join_party',
+  VIDEO_EVENT = 'video_event',
 }
 
 export interface CreatePartyResponse {
   roomId: string;
+}
+
+export enum VideoSocketEvents {
+  VIDEO_PLAY = 'video_play',
+  VIDEO_PAUSE = 'video_pause',
+  VIDEO_SEEKED = 'video_seeked',
+  VIDEO_PROGRESS = 'video_progress',
 }

--- a/src/lib/constants/video.ts
+++ b/src/lib/constants/video.ts
@@ -1,0 +1,1 @@
+export const MAX_DESYNC_SEC = 3;

--- a/src/lib/types/video.ts
+++ b/src/lib/types/video.ts
@@ -1,0 +1,15 @@
+import { VideoSocketEvents } from '@root/lib/constants/socket';
+
+export interface VideoEvent {
+  partyHash: string;
+  eventData: VideoEventData;
+}
+
+export interface VideoEventData {
+  isHost: boolean;
+  paused: boolean;
+  currentTime: number;
+  playbackRate: number;
+  duration: number;
+  eventType: VideoSocketEvents;
+}

--- a/src/lib/types/video.ts
+++ b/src/lib/types/video.ts
@@ -6,7 +6,6 @@ export interface VideoEvent {
 }
 
 export interface VideoEventData {
-  isHost: boolean;
   paused: boolean;
   currentTime: number;
   playbackRate: number;


### PR DESCRIPTION
### 📃 Summary
Clients will listen for video events emitted by the server.

### 🔍 What's the new behavior?
At the moment, only the host actually sends play/pause/seek events. All users send progress events. Host sends all events. When video event messages are received from the server, the client will only react to them if they are sent by the host.

When a client receives a video event sent by the host, the following happens:
1. The play/pause state of the host is matched by the receiving client
2. The playback rate of the host is matched by the receiving client
3. The current time of the host is matched by the receiving client only if the client's current video progress differs by more than a constant number of seconds, currently set to 3 (defined in `@root/lib/constants/video`)

### 🏷 Task Link
https://www.notion.so/e3d5c681f11944579bb402b8430dd906?v=ab2bd374515146ee83473fcb1df84002&p=c0ed4aa1df814a3490c2d633b1b0b841

https://www.notion.so/e3d5c681f11944579bb402b8430dd906?v=ab2bd374515146ee83473fcb1df84002&p=ad5e20e1a1eb4f5e935f23b5543d0622

### ↩️ Depends On
https://github.com/rkrishn7/couchsync-api/pull/6

### 🧪 QA
To play around with this, do the following.

1. Make sure the dependant PR is approved, merged into couchsync-api/main, and your server is up to date, or checkout the couchsync-api/sync-video branch.
2. Make sure the server is running
3. Navigate to a YouTube video and create a party
4. Join the party from another window/tab
5. Play around with playback rate, seeking, play/pause from host. Non-host should mimic the host.
