### PR TITLE
Autoplay disabled when in party

### DIFF
--- a/src/content-script/actions/party.ts
+++ b/src/content-script/actions/party.ts
@@ -4,6 +4,8 @@ import { debug } from '@root/lib/utils/debug';
 import { PartyState } from '@contentScript/reducers/party';
 import socket from '@contentScript/socket';
 
+import { disableAutoplay } from '@root/lib/utils';
+
 import { Dispatch } from 'redux';
 
 import { setUser } from './user';
@@ -22,6 +24,7 @@ export const joinParty = ({ hash, isHost }: any) => {
         dispatch(setParty({ isHost, ...party }));
         dispatch(setUser({ ...user }));
       });
+      disableAutoplay();
     } catch (error) {
       debug(error.message);
     }

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -15,3 +15,15 @@ export const inject = (fn: () => void) => {
 export const isValidExtensionUrl = (url: string) => {
   return url.match(/^.*:\/\/.*.youtube.com\/watch.*$/);
 };
+
+export const disableAutoplay = () => {
+  const autoPlayBtn = document.getElementsByClassName(
+    'style-scope ytd-compact-autoplay-renderer'
+  )[3] as HTMLInputElement;
+  if (autoPlayBtn.getAttribute('aria-pressed') === 'true') {
+    autoPlayBtn.click();
+  }
+  autoPlayBtn.setAttribute('disabled', 'disabled');
+  const autoPlayTxt = document.getElementsByClassName('style-scope ytd-compact-autoplay-renderer')[2] as HTMLElement;
+  autoPlayTxt.innerText = 'Autoplay Disabled when in Party';
+};


### PR DESCRIPTION
### 📃 Summary
Small new function to disable autoplay for when users are in a party.

### 🔍 What's the new behavior?
* Autoplay is disabled upon joining/creating a party with a small message next to it

### 🏷 Task Link

### ↩️ Depends On

Link any other PRs here.

### 🧪 QA

- List the steps to test the changes here.

### 🛑 Risk Analysis

- [ ] Does it update dependencies?
