### PR TITLE
Fix joining user not syncing when host paused

### DIFF
--- a/src/content-script/listeners/player.ts
+++ b/src/content-script/listeners/player.ts
@@ -69,6 +69,13 @@ function addVideoListeners(player: HTMLVideoElement) {
   player.onpause = sendVideoEvent(VideoSocketEvents.VIDEO_PAUSE);
   player.onseeked = sendVideoEvent(VideoSocketEvents.VIDEO_SEEKED);
   player.onprogress = sendVideoEvent(VideoSocketEvents.VIDEO_PROGRESS);
+
+  setInterval(function sendProgressOnPause() {
+    const { isHost } = store.getState().party;
+    if (isHost && player.paused) {
+      sendVideoEvent(VideoSocketEvents.VIDEO_PROGRESS);
+    }
+  }, 1000);
 }
 
 function addVideoSocketListeners(player: HTMLVideoElement) {


### PR DESCRIPTION
### 📃 Summary
A user's video player will emit no events when paused.

If the host was paused when a new user joined the party, their video
would autoplay and continue to play because no update events were being
sent by the host.

### 🔍 What's the new behavior?

Update events be sent every one second by paused hosts

### 🏷 Task Link

https://www.notion.so/e3d5c681f11944579bb402b8430dd906?v=ab2bd374515146ee83473fcb1df84002&p=7e165081b9f942f79b8780458080235c

### 🛑 Risk Analysis

- [x] Does not update dependencies
