### PR TITLE
fix: multiple video listeners bug

### DIFF
--- a/src/content-script/listeners/index.ts
+++ b/src/content-script/listeners/index.ts
@@ -25,8 +25,6 @@ window.addEventListener('message', event => {
   }
 });
 
-window.addEventListener('load', attachToVideoPlayer);
-
 // CANNOT REFERENCE ANY VARIABLES FROM OUTER SCOPE (They will not resolve)
 function addNavigationListeners() {
   /**


### PR DESCRIPTION
### 📃 Summary
Fix multiple video listeners bug

### 🔍 What's the new behavior?
Just attach video listeners on URL_CHANGE. URL_CHANGE also fires when the page is loaded.

### 🏷 Task Link
https://www.notion.so/e3d5c681f11944579bb402b8430dd906?v=ab2bd374515146ee83473fcb1df84002&p=6fc3d0c108514a359721726281cecbaa
