### PR TITLE
Task/conditional chat auto scroll

### DIFF
--- a/src/content-script/components/chat/chat.tsx
+++ b/src/content-script/components/chat/chat.tsx
@@ -96,7 +96,7 @@ const Chat: React.FC<ReduxProps> = ({ chatEnabled, partyId, toggleChat, partyUse
             </Flex>
             <Brand headingProps={{ fontWeight: 600 }} />
           </HeaderContainer>
-          <Flex flex={3} overflowY="scroll" padding={2}>
+          <Flex flex={3} overflowY="hidden" padding={2}>
             <MessageList />
           </Flex>
           <MessageBar />

--- a/src/content-script/components/message-list/message-list.tsx
+++ b/src/content-script/components/message-list/message-list.tsx
@@ -25,27 +25,38 @@ type ReduxProps = ConnectedProps<typeof connector>;
 const MessageList: React.FC<ReduxProps> = ({ messages }) => {
   const messageRefs = useRef({} as Record<number, HTMLDivElement | null>);
 
+  const isInViewport = (elem: HTMLDivElement | null) => {
+    const bounds = elem?.getBoundingClientRect();
+    if(!bounds) return true;
+    return (
+      bounds.top >= 0 &&
+      // using a magic number of 130
+      bounds.bottom <= (window.innerHeight || document.documentElement.clientHeight) - 130
+    );
+  };
+
   useEffect(() => {
     const lastMessageId = messages[messages.length - 1]?.id;
-    if (lastMessageId) {
+    if (lastMessageId && isInViewport(messageRefs.current[lastMessageId])) {
+      console.log(isInViewport(messageRefs.current[lastMessageId]))
       messageRefs.current[lastMessageId]?.scrollIntoView(false);
     }
   }, [messages]);
 
   return (
     <Container>
-      {messages?.map(({ content, isOwnMessage, user, id }) => (
-        <MessageCell
-          message={content}
-          isOwnMessage={isOwnMessage}
-          userName={user.name}
-          avatarUrl={user.avatarUrl}
-          key={id}
-          ref={ref => {
-            messageRefs.current[id] = ref;
-          }}
-        />
-      ))}
+        {messages?.map(({ content, isOwnMessage, user, id }) => (
+          <MessageCell
+            message={content}
+            isOwnMessage={isOwnMessage}
+            userName={user.name}
+            avatarUrl={user.avatarUrl}
+            key={id}
+            ref={ref => {
+              messageRefs.current[id] = ref;
+            }}
+          />
+        ))}
     </Container>
   );
 };

--- a/src/content-script/components/message-list/message-list.tsx
+++ b/src/content-script/components/message-list/message-list.tsx
@@ -27,7 +27,7 @@ const MessageList: React.FC<ReduxProps> = ({ messages }) => {
 
   const isInViewport = (elem: HTMLDivElement | null) => {
     const bounds = elem?.getBoundingClientRect();
-    if(!bounds) return true;
+    if (!bounds) return true;
     return (
       bounds.top >= 0 &&
       // using a magic number of 130
@@ -38,25 +38,24 @@ const MessageList: React.FC<ReduxProps> = ({ messages }) => {
   useEffect(() => {
     const lastMessageId = messages[messages.length - 1]?.id;
     if (lastMessageId && isInViewport(messageRefs.current[lastMessageId])) {
-      console.log(isInViewport(messageRefs.current[lastMessageId]))
       messageRefs.current[lastMessageId]?.scrollIntoView(false);
     }
   }, [messages]);
 
   return (
     <Container>
-        {messages?.map(({ content, isOwnMessage, user, id }) => (
-          <MessageCell
-            message={content}
-            isOwnMessage={isOwnMessage}
-            userName={user.name}
-            avatarUrl={user.avatarUrl}
-            key={id}
-            ref={ref => {
-              messageRefs.current[id] = ref;
-            }}
-          />
-        ))}
+      {messages?.map(({ content, isOwnMessage, user, id }) => (
+        <MessageCell
+          message={content}
+          isOwnMessage={isOwnMessage}
+          userName={user.name}
+          avatarUrl={user.avatarUrl}
+          key={id}
+          ref={ref => {
+            messageRefs.current[id] = ref;
+          }}
+        />
+      ))}
     </Container>
   );
 };


### PR DESCRIPTION
### 📃 Summary
There is an additional check for auto-scrolling when a new message arrives in chat to see if the user is looking at a previous message. The windows double-scrollbar should be fixed as well (not sure how it looks on mac).
### 🔍 What's the new behavior?
The chat box will now only auto-scroll to the bottom if the user is at the bottom of the chat box.
### 🏷 Task Link
https://www.notion.so/Task-update-chat-functionality-for-easier-UI-for-user-f67527b9accc42aabd8fa3eaa619ea1b
### ↩️ Depends On

Link any other PRs here.

### 🧪 QA

- List the steps to test the changes here.

Send messages in the chat until it overflows then scroll up to a previous message to see if sending a message auto-scrolls.
Also, open chat and send messages until it overflows on Mac to see if the scrollbar looks alright.

### 🛑 Risk Analysis

- [ ] Does it update dependencies?
